### PR TITLE
Fix broken logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
- <img alt="Jupyter Accessibility logo" src="https://github.com/jupyter/accessibility/blob/main/docs/_static/logo.png?raw=true" width="250" />
+ <img alt="Jupyter Accessibility logo" src="https://github.com/jupyter/accessibility/blob/main/docs/_static/logos/jupyter_accessibility.png?raw=true" width="250" />
 </div>
 <br>
 


### PR DESCRIPTION
Part of https://github.com/Quansight-Labs/jupyterlab-accessible-themes/issues/56

This PR fixes the broken logo in main readme