### PR TITLE
Fix Github Light and Pitaya Smoothie contrast color bugs

### DIFF
--- a/packages/githublight/style/index.css
+++ b/packages/githublight/style/index.css
@@ -98,4 +98,29 @@ pre {
   background-color: var(--gh-light-white);
 }
 
+/* --------------------------------------
+/* Change menu item style
+-----------------------------------------*/
+.lm-Menu-item:hover[data-type='command'] {
+  background: var(--gh-light-gray5);
+  color: var(--gh-light-white);
+}
+
+.lm-Menu-item:hover[data-type='submenu'] {
+  background: var(--gh-light-gray5);
+  color: var(--gh-light-white);
+}
+
+.lm-Menu-item[data-type='separator'] > div::after {
+  border-top: var(--jp-border-width) solid var(--gh-light-gray5);
+}
+
+.jp-switch-track {
+  background: var(--gh-light-gray5);
+}
+
+.jp-switch-track::before {
+  color: var(--gh-light-white);
+}
+
 /*# sourceMappingURL=index.css.map */

--- a/packages/githublight/style/index.css
+++ b/packages/githublight/style/index.css
@@ -31,7 +31,7 @@ pre {
 /* Change tab style
 -----------------------------------------*/
 .lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current:before {
-  background: var(--gh-light-white);
+  background: var(--gh-light-blue6);
 }
 
 .jp-FileBrowser-toolbar .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher'] {

--- a/packages/githublight/style/index.css
+++ b/packages/githublight/style/index.css
@@ -101,17 +101,17 @@ pre {
 /* --------------------------------------
 /* Change menu item style
 -----------------------------------------*/
-.lm-Menu-item:hover[data-type='command'] {
+.lm-Menu-item:hover[data-type="command"] {
   background: var(--gh-light-gray5);
   color: var(--gh-light-white);
 }
 
-.lm-Menu-item:hover[data-type='submenu'] {
+.lm-Menu-item:hover[data-type="submenu"] {
   background: var(--gh-light-gray5);
   color: var(--gh-light-white);
 }
 
-.lm-Menu-item[data-type='separator'] > div::after {
+.lm-Menu-item[data-type="separator"] > div::after {
   border-top: var(--jp-border-width) solid var(--gh-light-gray5);
 }
 

--- a/packages/githublight/style/variables.css
+++ b/packages/githublight/style/variables.css
@@ -179,10 +179,10 @@ https://github.com/primer/primitives/blob/main/data/colors/themes/light.ts.
   * The following variables, specify the visual styling of borders in JupyterLab.
   */
   --jp-border-width: 1px;
-  --jp-border-color0: var(--gh-light-gray0);
-  --jp-border-color1: var(--gh-light-gray1);
-  --jp-border-color2: var(--gh-light-gray2);
-  --jp-border-color3: var(--gh-light-gray3);
+  --jp-border-color0: var(--gh-light-gray2);
+  --jp-border-color1: var(--gh-light-gray3);
+  --jp-border-color2: var(--gh-light-gray4);
+  --jp-border-color3: var(--gh-light-gray5);
   --jp-border-radius: 2px;
   /* UI Fonts
   *
@@ -281,10 +281,10 @@ https://github.com/primer/primitives/blob/main/data/colors/themes/light.ts.
   --jp-layout-color1: var(--gh-light-gray0);
   /* activity bar, inactive tab, status bar*/
   /* here use same as inactive tabs */
-  --jp-layout-color2: var(--gh-light-gray0);
+  --jp-layout-color2: var(--gh-light-gray1);
   /* editor/notebok surrounding area */
-  --jp-layout-color3: var(--gh-light-gray0);
-  --jp-layout-color4: var(--gh-light-gray0);
+  --jp-layout-color3: var(--gh-light-gray2);
+  --jp-layout-color4: var(--gh-light-gray3);
   /* Inverse Layout
   *
   * The following are the inverse layout colors use in JupyterLab. In a light
@@ -322,10 +322,10 @@ https://github.com/primer/primitives/blob/main/data/colors/themes/light.ts.
   --jp-accent-color2: var(--gh-light-blue2);
   --jp-accent-color3: var(--gh-light-blue1);
   /* State colors (warn, error, success, info) */
-  --jp-warn-color0: var(--gh-light-gray6);
-  --jp-warn-color1: var(--gh-light-gray5);
-  --jp-warn-color2: var(--gh-light-gray4);
-  --jp-warn-color3: var(--gh-light-gray3);
+  --jp-warn-color0: var(--gh-light-orange6);
+  --jp-warn-color1: var(--gh-light-orange5);
+  --jp-warn-color2: var(--gh-light-orange4);
+  --jp-warn-color3: var(--gh-light-orange3);
   --jp-error-color0: var(--gh-light-red4);
   --jp-error-color1: var(--gh-light-red3);
   --jp-error-color2: var(--gh-light-red2);
@@ -439,6 +439,8 @@ https://github.com/primer/primitives/blob/main/data/colors/themes/light.ts.
   --jp-scrollbar-thumb-radius: 9px;
   /* set to a large-ish value for rounded endcaps on the thumb */
   --jp-icon-contrast-color0: var(--gh-light-gray6);
+  /* set input active box shadow color for the main search */
+  --jp-input-active-box-shadow-color: var(--gh-light-blue6);
 }
 
 /*# sourceMappingURL=variables.css.map */

--- a/packages/githublight/style/variables.css
+++ b/packages/githublight/style/variables.css
@@ -211,9 +211,9 @@ https://github.com/primer/primitives/blob/main/data/colors/themes/light.ts.
   /* active item */
   --jp-ui-font-color0: var(--gh-light-black);
   /* sidebar files & top menu */
-  --jp-ui-font-color1: var(--gh-light-gray9);
-  --jp-ui-font-color2: var(--gh-light-gray8);
-  --jp-ui-font-color3: var(--gh-light-gray7);
+  --jp-ui-font-color1: var(--gh-light-gray8);
+  --jp-ui-font-color2: var(--gh-light-gray6);
+  --jp-ui-font-color3: var(--gh-light-gray5);
   /*
   * Use these against the brand/accent/warn/error colors.
   * These will typically go from light to darker, in both a dark and light theme.

--- a/packages/pitayasmoothie/style/variables.css
+++ b/packages/pitayasmoothie/style/variables.css
@@ -79,6 +79,8 @@ smoothie main theme, https://github.com/trallard/pitaya_smoothie.
   --pitaya-active-items-foreground: var(--pitaya-periwinkle-extra1);
   --pitaya-hihglight: rgba(50, 31, 122, 0.85);
   --pitaya-hihglight-focused: rgba(50, 31, 122, 0.8);
+  /* Make status bar */
+  --jp-statusbar-height: 24px;
   /* Elevation
   *
   * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:
@@ -393,6 +395,13 @@ smoothie main theme, https://github.com/trallard/pitaya_smoothie.
   /* the space in between the sides of the thumb and the track */
   --jp-scrollbar-thumb-radius: 9px;
   /* set to a large-ish value for rounded endcaps on the thumb */
+  /* set icon contrast colors */
+  --jp-icon-contrast-color0: var(--pitaya-lilac300);
+  --jp-icon-contrast-color1: var(--pitaya-lilac300);
+  --jp-icon-contrast-color2: var(--pitaya-lilac300);
+  --jp-icon-contrast-color3: var(--pitaya-lilac400);
+  /* set input active box shadow color for the main search */
+  --jp-input-active-box-shadow-color: var(--pitaya-lilac300);
 }
 
 /*# sourceMappingURL=variables.css.map */


### PR DESCRIPTION
Fixes #59 

This PR,

- [x] Fixes the issues found in the Pitaya Smoothie and Github Light themes.

Here are some screenshots on how the current themes look,

**Github Light**

- [x] The active tab colour is noticeable
- [x] Hover background (menu) has enough contrast against the background colour
- [x] Colours in the kernel/tab manager sidebar 
- [x] Active indicator on the search bar
- [x] Toggle background is noticeable in the status bar

<img width="1792" alt="image" src="https://github.com/Quansight-Labs/jupyterlab-accessible-themes/assets/20992645/cd134408-bf61-4949-b49c-c676af99d47c">

<img width="522" alt="image" src="https://github.com/Quansight-Labs/jupyterlab-accessible-themes/assets/20992645/063d5947-6362-4217-9126-ccc3e78b7a64">

<img width="323" alt="image" src="https://github.com/Quansight-Labs/jupyterlab-accessible-themes/assets/20992645/9a9010bd-814e-4085-a911-5c2ce9b91df4">

<img width="331" alt="image" src="https://github.com/Quansight-Labs/jupyterlab-accessible-themes/assets/20992645/d3e1c195-8b7a-467d-ad0e-e8cd7c74bd06">


**Pitaya Smoothie**

- [x] Icons have enough contrast against the background
- [x] Active indicator on the search bar

<img width="537" alt="image" src="https://github.com/Quansight-Labs/jupyterlab-accessible-themes/assets/20992645/1fdc94d8-cb67-4aa7-b309-c7dff694cf4d">


