### PR TITLE
Update pyproject.toml and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,20 +147,20 @@ conda uninstall jupyterlab_accessible_themes
    # Link your development version of the extension with JupyterLab
    jupyter labextension develop . --overwrite
    ```
-   
-9. On the first installation, or after making some changes, to visualize them in your local JupyterLab re-run the following command:
+
+8. On the first installation, or after making some changes, to visualize them in your local JupyterLab re-run the following command:
 
    ```bash
    # Rebuild extension Typescript source after making changes
    jlpm build
    ```
 
-10. Run JupyterLab and check that the installation worked:
+9. Run JupyterLab and check that the installation worked:
 
-   ```bash
-   # Run JupyterLab
-   jupyter lab
-   ```
+```bash
+# Run JupyterLab
+jupyter lab
+```
 
 > **Important**
 > Once everything is installed, you will need to select the theme inside JupyterLab via the main menu `Settings > Theme`.

--- a/README.md
+++ b/README.md
@@ -142,14 +142,20 @@ conda uninstall jupyterlab_accessible_themes
    ```
 
 7. Now you'll need to link the development version of the extension to JupyterLab and rebuild the Typescript source:
-   On the first installation, or after making some changes, to visualize them in your local JupyterLab re-run the following command:
+
+   ```bash
+   # Link your development version of the extension with JupyterLab
+   jupyter labextension develop . --overwrite
+   ```
+   
+9. On the first installation, or after making some changes, to visualize them in your local JupyterLab re-run the following command:
 
    ```bash
    # Rebuild extension Typescript source after making changes
    jlpm build
    ```
 
-8. Run JupyterLab and check that the installation worked:
+10. Run JupyterLab and check that the installation worked:
 
    ```bash
    # Run JupyterLab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "jupyter_packaging.build_api"
 [project]
 name = "jupyterlab_accessible_themes"
 requires-python = ">=3.8"
+dynamic = ["version", "description", "readme", "license", "authors", "urls"]
 
 [tool.jupyter-packaging.options]
 skip-if-exists = ["jupyterlab_accessible_themes/labextension/static/style.js"]


### PR DESCRIPTION
This PR,

- [x] Fixes the pyproject.toml file to avoid build and installation errors
- [x] Reverts a change made in the Readme in https://github.com/Quansight-Labs/jupyterlab-accessible-themes/pull/63/

---

## `pyproject.toml`

This change is necessary for fixing build and installation errors using the pyproject.toml

This is one of the errors that was appearing,

```
The following seems to be defined outside of `pyproject.toml`:
`authors = 'quansight-labs'`
According to the spec (see the link below), however, setuptools CANNOT
consider this value unless `authors` is listed as `dynamic`.
https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
For the time being, `setuptools` will still consider the given value (as a
**transitional** measure), but please note that future releases of setuptools will
follow strictly the standard.
To prevent this warning, you can list `authors` under `dynamic` or alternatively
remove the `[project]` table from your file and rely entirely on other means of
configuration.
By 2023-Oct-30, you need to update your project and remove deprecated calls
or your builds will no longer be supported.
```

## `readme`

One **necessary** step of the local installation process was removed from the instructions